### PR TITLE
Fix Travis Badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![geli-Logo](.var/geli-readme-icon.png)
 
 [![GitHub release](https://img.shields.io/github/release/utetrapp/geli.svg)](https://github.com/utetrapp/geli/releases)
-[![Build Status](https://travis-ci.org/utetrapp/geli.svg?branch=develop)](https://travis-ci.org/utetrapp/geli)
+[![Build Status](https://travis-ci.com/geli-lms/geli.svg?branch=develop)](https://travis-ci.org/utetrapp/geli)
 [![Coverage Status](https://coveralls.io/repos/github/utetrapp/geli/badge.svg?branch=develop)](https://coveralls.io/github/utetrapp/geli?branch=develop)
 [![Uptime Robot ratio](https://img.shields.io/uptimerobot/ratio/m779032297-cd1143fdc10b510896f2a344.svg)](https://stats.uptimerobot.com/mq8EDc8lx)
 [![Gitter chat](https://badges.gitter.im/utetrapp/geli.png)](https://gitter.im/mpse-geli/Lobby)


### PR DESCRIPTION
## Description:

fixes Badge url in readme to match new organisation account

## Improvements
- 

## Known Issues:
_NONE_

