### PR TITLE
Rebuild phantomjs inside docker

### DIFF
--- a/.docker/api/Dockerfile
+++ b/.docker/api/Dockerfile
@@ -9,6 +9,8 @@ EXPOSE 80
 
 CMD node server.js
 
+RUN apt-get update -y && apt-get install libfontconfig1 -y
+
 RUN mkdir -p /usr/src/app/uploads
 RUN mkdir -p /usr/src/app/uploads/courses
 
@@ -18,3 +20,7 @@ RUN chmod a+rwx /usr/src/app/tmp
 COPY api/build/src /usr/src/app/
 COPY api/node_modules /usr/src/app/node_modules
 COPY api/nlf-licenses.json /usr/src/app/
+COPY api/package.json /usr/src/app/
+COPY api/package-lock.json /usr/src/app/
+
+RUN npm rebuild

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Form validation before submit when creating a new course. [#724](https://github.com/geli-lms/geli/pull/724)
 - ID validation of the `CourseController` `/api/courses/:id` route. [#724](https://github.com/geli-lms/geli/pull/724)
 - Possibility to add files directly in the file unit. [#728](https://github.com/geli-lms/geli/issues/728)
+- Execute npm rebuild in docker. [#855](https://github.com/geli-lms/geli/pull/855)
 
 ### Changed
 - Minor fixes and adaptations and merge-failure fixes. [#785](https://github.com/geli-lms/geli/issues/785)


### PR DESCRIPTION
## Description:

We copy `node_modules` into the docker image. I suppose that the phantomjs version for travis ci does not work for the docker image. This pull request add package.json / package-lock.json into the container and execute npm rebuild during docker build.
 https://github.com/geli-lms/geli/blob/fdaec950f59f628a8cdb9ac5813da3e01d652c2b/.docker/api/Dockerfile#L19

> PhantomJS needs to be compiled separately for each platform. This installer finds a prebuilt binary for your operating system, and downloads it.

> If you check your dependencies into git, and work on a cross-platform team, then you need to tell NPM to rebuild any platform-specific dependencies. Run

https://www.npmjs.com/package/phantomjs-prebuilt#cross-platform-repositories

> There is no requirement to install Qt, WebKit, or any other libraries. It however still relies on Fontconfig (the package fontconfig or libfontconfig, depending on the distribution).

https://www.npmjs.com/package/phantomjs-prebuilt#linux-note

## Improvements
- A working version ofr phantomjs is shipped with docker image
- Export as PDF work

## Known Issues:
_NONE_

<!--
ATTENTION:
Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix.
-->
