### PR TITLE
Bugfix/#897 ChatRoomController internal data leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Various flawed code kata translations. [#886](https://github.com/geli-lms/geli/issues/886)
 - Migrations for adding chatrooms to course and unit. [#886](https://github.com/geli-lms/geli/issues/888)
 - `AuthController` `addWhitelistedUserToCourses` broken condition & typos. [#895](https://github.com/geli-lms/geli/issues/895)
+- `ChatRoomController` internal data leak. [#897](https://github.com/geli-lms/geli/issues/897)
 
 ### Security
 - Secured the static `'uploads'` route by introducing a special `'mediaToken'` with new JWT strategy & middleware. [#729](https://github.com/geli-lms/geli/issues/729)

--- a/api/src/config/errorCodes.ts
+++ b/api/src/config/errorCodes.ts
@@ -1,4 +1,10 @@
 export const errorCodes = {
+  chat: {
+    roomNotFound: {
+      code: 'chat room not found',
+      text: 'Chat room was not found.',
+    },
+  },
   mail: {
     duplicate: {
       code: 'duplicate mail',

--- a/api/src/controllers/ChatRoomController.ts
+++ b/api/src/controllers/ChatRoomController.ts
@@ -37,6 +37,6 @@ export default class ChatRoomController {
     if (!chatRoom) {
       throw new NotFoundError('chat room not found');
     }
-    return chatRoom;
+    return chatRoom.toObject();
   }
 }

--- a/api/src/controllers/ChatRoomController.ts
+++ b/api/src/controllers/ChatRoomController.ts
@@ -5,6 +5,7 @@ import {
   Param,
   UseBefore
 } from 'routing-controllers';
+import {errorCodes} from '../config/errorCodes';
 import {ChatRoom} from '../models/ChatRoom';
 
 @JsonController('/chatRoom')
@@ -35,7 +36,7 @@ export default class ChatRoomController {
   async getChatRoom(@Param('id') id: string) {
     const chatRoom = await ChatRoom.findById(id);
     if (!chatRoom) {
-      throw new NotFoundError('chat room not found');
+      throw new NotFoundError(errorCodes.chat.roomNotFound.text);
     }
     return chatRoom.toObject();
   }


### PR DESCRIPTION
## Description:

Fixes an internal-data leak in `ChatRoomController` (`{get} /api/chatRoom`).

Closes #897

## Improvements
- Fixes the leak by appending `.toObject()` to the route's `return chatRoom`.
- _Opportunistic improvement:_ Move (single) `NotFoundError` message to `errorCodes.ts`.

## Known Issues:
_NONE_

<!--
ATTENTION:
Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix.
-->
