### PR TITLE
Remove broken toObject method

### DIFF
--- a/api/src/models/units/FileUnit.ts
+++ b/api/src/models/units/FileUnit.ts
@@ -19,13 +19,6 @@ const fileUnitSchema = new mongoose.Schema({
     type: String,
     required: true
   }
-}, {
-  toObject: {
-    transform: function (doc: any, ret: any) {
-      ret._id = ret._id.toString();
-      ret._course = ret._course.toString();
-    }
-  },
 });
 
 fileUnitSchema.methods.populateUnit = async function() {


### PR DESCRIPTION
## Description:

Found this one while testing live -> 0.8. There is a working `toObject` method in Unit and it should be safe to drop these in FileUnit. https://github.com/geli-lms/geli/blob/a9bbe854524c421d0ade51436c42a555c1c6a5bd/api/src/models/units/Unit.ts#L63-L78

