### PR TITLE
Translation course media & access key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Minor fixes and adaptations and merge-failure fixes. [#785](https://github.com/geli-lms/geli/issues/785)
-- Reworked existing translations. [#753](https://github.com/geli-lms/geli/issues/753)
+- Reworked existing translations. [#753](https://github.com/geli-lms/geli/issues/753), [#906](https://github.com/geli-lms/geli/pull/906)
 - Migrate `MatSnackBar` to `SnackBarService`. [#724](https://github.com/geli-lms/geli/pull/724) [#730](https://github.com/geli-lms/geli/pull/730)
 - Reload user list after deleting an account. [#724](https://github.com/geli-lms/geli/pull/724)
 - `getNotificationSettings` does not create new notification settings. [#731](https://github.com/geli-lms/geli/issues/731)

--- a/app/webFrontend/src/app/course/course-edit/course-media/course-media.component.html
+++ b/app/webFrontend/src/app/course/course-edit/course-media/course-media.component.html
@@ -110,15 +110,15 @@
 
             <div class="card-btn-wrapper" *ngIf="isInSelectedFiles(file)">
               <button mat-raised-button *ngIf="selectedFiles.length <= 1" (click)="$event.stopPropagation();initFileDownload(file)"
-                      matTooltip="'common.openInTab' | translate">
+                      [matTooltip]="'common.openInTab' | translate">
                 <mat-icon>open_in_new</mat-icon>
               </button>
               <button mat-raised-button *ngIf="selectedFiles.length <= 1" (click)="renameFile(file)"
-                      matTooltip="'common.rename' | translate">
+                      [matTooltip]="'common.rename' | translate">
                 <mat-icon>mode_edit</mat-icon>
               </button>
               <button mat-raised-button color="warn" (click)="removeSelectedFile()" *ngIf="selectedFiles.length <= 1"
-                      matTooltip="'common.delete' | translate">
+                      [matTooltip]="'common.delete' | translate">
                 <mat-icon>delete</mat-icon>
               </button>
             </div>

--- a/app/webFrontend/src/app/shared/components/access-key-dialog/access-key-dialog.component.html
+++ b/app/webFrontend/src/app/shared/components/access-key-dialog/access-key-dialog.component.html
@@ -2,7 +2,7 @@
 <div mat-dialog-content>{{ 'course.text.enterAccessKey' | translate }}</div>
 <div>
   <mat-form-field class="full-width">
-    <input async matInput type="password" id="accessKey" placeholder="'course.placeholder.accessKey' | translate" [(ngModel)]="accessKey"
+    <input async matInput type="password" id="accessKey" [placeholder]="'course.placeholder.accessKey' | translate" [(ngModel)]="accessKey"
            [ngModelOptions]="{standalone: true}">
   </mat-form-field>
 </div>


### PR DESCRIPTION
## Description:

Fix wrong call for translation. Buttons in course media. Placeholder for access key


## Improvements
- String is translated

## Known Issues:
_NONE_

<!--
ATTENTION:
Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix.
-->
