### PR TITLE
Add fileUnitType for FileUnit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Execute npm rebuild in docker. [#855](https://github.com/geli-lms/geli/pull/855)
 - Sentry reporting for missing translations. [#858](https://github.com/geli-lms/geli/issues/858)
 - Migration for `visible` field. [#890](https://github.com/geli-lms/geli/pull/890)
+- Migration for `fileUnitType` field. [#907](https://github.com/geli-lms/geli/pull/907)
 
 ### Changed
 - Minor fixes and adaptations and merge-failure fixes. [#785](https://github.com/geli-lms/geli/issues/785)

--- a/api/src/migrations/scripts/20181019-fileUnit.ts
+++ b/api/src/migrations/scripts/20181019-fileUnit.ts
@@ -1,0 +1,22 @@
+// tslint:disable:no-console
+
+import {IUnitModel, Unit} from '../../models/units/Unit';
+
+class FileUnitMigration20181019 {
+
+  async up() {
+    const fileUnitTypeMissing: IUnitModel[] = await Unit.find({__t: 'file', fileUnitType: {$exists: false}});
+
+    for (const unit of fileUnitTypeMissing) {
+      try {
+        await unit.save({validateBeforeSave: false});
+      } catch (error) {
+        console.log('Could not add "fileUnitType" to unit ' + unit.name + ' error: ' + error);
+      }
+    }
+
+    return true;
+  }
+}
+
+export = FileUnitMigration20181019;

--- a/api/src/migrations/scripts/20181019-fileUnit.ts
+++ b/api/src/migrations/scripts/20181019-fileUnit.ts
@@ -1,14 +1,16 @@
 // tslint:disable:no-console
 
-import {IUnitModel, Unit} from '../../models/units/Unit';
+import {Unit} from '../../models/units/Unit';
+import {IFileUnitModel} from '../../models/units/FileUnit';
 
 class FileUnitMigration20181019 {
 
   async up() {
-    const fileUnitTypeMissing: IUnitModel[] = await Unit.find({__t: 'file', fileUnitType: {$exists: false}});
+    const fileUnitTypeMissing: IFileUnitModel[] = <any>await Unit.find({__t: 'file', fileUnitType: {$exists: false}});
 
     for (const unit of fileUnitTypeMissing) {
       try {
+        unit.fileUnitType = 'file';
         await unit.save({validateBeforeSave: false});
       } catch (error) {
         console.log('Could not add "fileUnitType" to unit ' + unit.name + ' error: ' + error);


### PR DESCRIPTION
## Description:

For some units the field fileUnitType is missing. Save the record
again does the trick.

## Improvements
- No warning when migration data

## Known Issues:
_NONE_

