### PR TITLE
PDF export: Use random hash as file name for temp file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Unit-specific comments. [#761](https://github.com/geli-lms/geli/issues/761)
 - Simple E2E test for login. [#795](https://github.com/geli-lms/geli/pull/795)
 - Checkboxes for accepting our terms of use and privacy declarations while registering. [#778](https://github.com/geli-lms/geli/issues/778)
-- PDF course content download functionality. [#720](https://github.com/geli-lms/geli/pull/720)[#913](https://github.com/geli-lms/geli/issues/913)
+- PDF course content download functionality. [#720](https://github.com/geli-lms/geli/pull/720), [#913](https://github.com/geli-lms/geli/issues/913)
 - User data deletion functionality for EU-GDPR compliance. [#775](https://github.com/geli-lms/geli/issues/775)
 - Personal data export functionality for EU-GDPR compliance. [#805](https://github.com/geli-lms/geli/issues/805)
 - Guided dialog for adding a whitelist. [#727](https://github.com/geli-lms/geli/issues/727) [#509](https://github.com/geli-lms/geli/issues/509)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Unit-specific comments. [#761](https://github.com/geli-lms/geli/issues/761)
 - Simple E2E test for login. [#795](https://github.com/geli-lms/geli/pull/795)
 - Checkboxes for accepting our terms of use and privacy declarations while registering. [#778](https://github.com/geli-lms/geli/issues/778)
-- PDF course content download functionality. [#720](https://github.com/geli-lms/geli/pull/720)
+- PDF course content download functionality. [#720](https://github.com/geli-lms/geli/pull/720)[#913](https://github.com/geli-lms/geli/issues/913)
 - User data deletion functionality for EU-GDPR compliance. [#775](https://github.com/geli-lms/geli/issues/775)
 - Personal data export functionality for EU-GDPR compliance. [#805](https://github.com/geli-lms/geli/issues/805)
 - Guided dialog for adding a whitelist. [#727](https://github.com/geli-lms/geli/issues/727) [#509](https://github.com/geli-lms/geli/issues/509)

--- a/api/src/controllers/DownloadController.ts
+++ b/api/src/controllers/DownloadController.ts
@@ -26,8 +26,6 @@ const pdf =  require('html-pdf');
 const phantomjs = require('phantomjs-prebuilt');
 const binPath = phantomjs.path;
 
-const PDFtempPath = config.tmpFileCacheFolder + 'temp.pdf';
-
 // Set all routes which should use json to json, the standard is blob streaming data
 @Controller('/download')
 @UseBefore(passportJwtMiddleware)

--- a/api/src/controllers/DownloadController.ts
+++ b/api/src/controllers/DownloadController.ts
@@ -202,15 +202,15 @@ export class DownloadController {
         let lecCounter = 1;
         for (const lec of data.lectures) {
 
-          // create hashed pdf file
-          const tempPdfFileName = this.tempPdfFileName(user);
-
           const localLecture = await Lecture.findOne({_id: lec.lectureId});
           const lcName = this.replaceCharInFilename(localLecture.name);
           let unitCounter = 1;
 
           for (const unit of lec.units) {
             const localUnit = await Unit.findOne({_id: unit.unitId});
+
+            // create hashed pdf file
+            const tempPdfFileName = this.tempPdfFileName(user);
 
             if (!localUnit) {
               throw new NotFoundError();

--- a/api/src/controllers/DownloadController.ts
+++ b/api/src/controllers/DownloadController.ts
@@ -165,8 +165,6 @@ export class DownloadController {
   @Post('/pdf/individual')
   @ContentType('application/json')
   async postDownloadRequestPDFIndividual(@Body() data: IDownload, @CurrentUser() user: IUser) {
-    // create hashed pdf file
-    const tempPdfFileName = this.tempPdfFileName(user);
 
     const course = await Course.findOne({_id: data.courseName});
 
@@ -203,6 +201,9 @@ export class DownloadController {
 
         let lecCounter = 1;
         for (const lec of data.lectures) {
+
+          // create hashed pdf file
+          const tempPdfFileName = this.tempPdfFileName(user);
 
           const localLecture = await Lecture.findOne({_id: lec.lectureId});
           const lcName = this.replaceCharInFilename(localLecture.name);
@@ -253,15 +254,14 @@ export class DownloadController {
                 html += '</html>';
               const name = lecCounter + '_' + lcName + '/' + unitCounter + '_' + this.replaceCharInFilename(localUnit.name) + '.pdf';
               await this.savePdfToFile(html, options, tempPdfFileName);
-
               await this.appendToArchive(archive, name, tempPdfFileName, hash);
-
+              fs.unlinkSync(tempPdfFileName);
             }
             unitCounter++;
           }
           lecCounter++;
         }
-        fs.unlinkSync(tempPdfFileName);
+
         return new Promise((resolve, reject) => {
           archive.on('error', () => reject(hash));
           archive.finalize();

--- a/api/src/controllers/DownloadController.ts
+++ b/api/src/controllers/DownloadController.ts
@@ -167,6 +167,10 @@ export class DownloadController {
   @Post('/pdf/individual')
   @ContentType('application/json')
   async postDownloadRequestPDFIndividual(@Body() data: IDownload, @CurrentUser() user: IUser) {
+    // create hashed pdf file
+    const hashPdfFileName = config.tmpFileCacheFolder +
+      crypto.createHash('sha1').update(new Date() + user._id).digest('hex').toString().slice(0,16) +
+      '_temp.pdf';
 
     const course = await Course.findOne({_id: data.courseName});
 
@@ -252,16 +256,16 @@ export class DownloadController {
                 html += localUnit.toHtmlForIndividualPDF();
                 html += '</html>';
               const name = lecCounter + '_' + lcName + '/' + unitCounter + '_' + this.replaceCharInFilename(localUnit.name) + '.pdf';
-              await this.savePdfToFile(html, options, PDFtempPath);
+              await this.savePdfToFile(html, options, hashPdfFileName);
 
-              await this.appendToArchive(archive, name, PDFtempPath, hash);
+              await this.appendToArchive(archive, name, hashPdfFileName, hash);
 
             }
             unitCounter++;
           }
           lecCounter++;
         }
-        fs.unlinkSync(PDFtempPath);
+        fs.unlinkSync(hashPdfFileName);
         return new Promise((resolve, reject) => {
           archive.on('error', () => reject(hash));
           archive.finalize();
@@ -294,6 +298,10 @@ export class DownloadController {
   @Post('/pdf/single')
   @ContentType('application/json')
   async postDownloadRequestPDFSingle(@Body() data: IDownload, @CurrentUser() user: IUser) {
+
+    const hashPdfFileName = config.tmpFileCacheFolder +
+      crypto.createHash('sha1').update(new Date() + user._id).digest('hex').toString().slice(0,16) +
+      '_temp.pdf';
 
     const course = await Course.findOne({_id: data.courseName});
 
@@ -427,9 +435,9 @@ export class DownloadController {
         html += '</div></body>' +
           '</html>';
         const name = this.replaceCharInFilename(course.name) + '.pdf';
-        await this.savePdfToFile(html, options, PDFtempPath);
-        await this.appendToArchive(archive, name, PDFtempPath, hash);
-        fs.unlinkSync(PDFtempPath);
+        await this.savePdfToFile(html, options, hashPdfFileName);
+        await this.appendToArchive(archive, name, hashPdfFileName, hash);
+        fs.unlinkSync(hashPdfFileName);
         return new Promise((resolve, reject) => {
           archive.on('error', () => reject(hash));
           archive.finalize();


### PR DESCRIPTION
## Description:
Pdf export will no longer use the same temp.pdf file for all users (parallel downloading not supported).
Instead the temp file has a hash in its name now. (the hash is calulated by current Date and Userid)

Ref #913 

## Improvements
- Simultaneous Pdf Download

## Known Issues:
_NONE_

<!--
ATTENTION:
Remember to prefix your PR-Title with ` ` if you still work on it.
If you have reached a final state, remove the prefix.
-->
