### PR TITLE
Fix delete lecture api endpoint type mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Minor `ConfigController` bugs and refactoring-flaws. [#899](https://github.com/geli-lms/geli/issues/899)
 - Don't pin `@types/express` to a specific version. [#947](https://github.com/geli-lms/geli/pull/947)
-- Switched to cookie-based JWT authentication. [#840](https://github.com/geli-lms/geli/issues/840)
+- Switched to cookie-based JWT authentication. [#840](https://github.com/geli-lms/geli/issues/840) [#968](https://github.com/geli-lms/geli/issues/968)
 - Update typescript dependancy to v3.1.5 (API) [#957](https://github.com/geli-lms/geli/pull/957), [#967](https://github.com/geli-lms/geli/pull/967)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Minor `ConfigController` bugs and refactoring-flaws. [#899](https://github.com/geli-lms/geli/issues/899)
 - Don't pin `@types/express` to a specific version. [#947](https://github.com/geli-lms/geli/pull/947)
 - Switched to cookie-based JWT authentication. [#840](https://github.com/geli-lms/geli/issues/840)
+- Update typescript dependancy to v3.1.5 (API) [#957](https://github.com/geli-lms/geli/pull/957), [#967](https://github.com/geli-lms/geli/pull/967)
 
 ### Removed
 - Remove `@types/winston`. [#945](https://github.com/geli-lms/geli/pull/945)

--- a/api/package.json
+++ b/api/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^3.0.0",
-    "@types/body-parser": "1.16.8",
+    "@types/body-parser": "1.17.0",
     "@types/chai": "4.1.7",
     "@types/chai-http": "3.0.5",
     "@types/cookie": "^0.3.1",

--- a/api/src/controllers/LectureController.ts
+++ b/api/src/controllers/LectureController.ts
@@ -112,6 +112,8 @@ export class LectureController {
    * @api {delete} /api/lecture/:id Delete lecture
    * @apiName DeleteLecture
    * @apiGroup Lecture
+   * @apiPermission teacher
+   * @apiPermission admin
    *
    * @apiParam {String} id Lecture ID.
    *
@@ -125,15 +127,17 @@ export class LectureController {
   @Authorized(['teacher', 'admin'])
   @Delete('/:id')
   async deleteLecture(@Param('id') id: string, @CurrentUser() currentUser: IUser) {
-    const course = await Course.findOne({where: {lectures: id}});
+    const course = await Course.findOne({ lectures: id});
     if (!course) {
       throw new NotFoundError();
     }
-    if (!course.checkPrivileges(currentUser).userCanEditCourse()) {
+    if (!course.checkPrivileges(currentUser).userCanEditCourse) {
       throw new ForbiddenError();
     }
-    const success = await course.update({}, {$pull: {lectures: id}});
+    await course.update({}, {$pull: {lectures: id}});
 
-    return Lecture.findByIdAndRemove(id) && success;
+    await Lecture.findByIdAndRemove(id);
+
+    return {result: true};
   }
 }

--- a/api/src/controllers/LectureController.ts
+++ b/api/src/controllers/LectureController.ts
@@ -120,9 +120,7 @@ export class LectureController {
    * @apiSuccess {Boolean} result Confirmation of deletion.
    *
    * @apiSuccessExample {json} Success-Response:
-   *     {
-   *         "result": true
-   *     }
+   *     {}
    */
   @Authorized(['teacher', 'admin'])
   @Delete('/:id')
@@ -138,6 +136,6 @@ export class LectureController {
 
     await Lecture.findByIdAndRemove(id);
 
-    return {result: true};
+    return {};
   }
 }

--- a/api/src/controllers/LectureController.ts
+++ b/api/src/controllers/LectureController.ts
@@ -127,7 +127,7 @@ export class LectureController {
   @Authorized(['teacher', 'admin'])
   @Delete('/:id')
   async deleteLecture(@Param('id') id: string, @CurrentUser() currentUser: IUser) {
-    const course = await Course.findOne({ lectures: id});
+    const course = await Course.findOne({lectures: id});
     if (!course) {
       throw new NotFoundError();
     }

--- a/api/src/controllers/LectureController.ts
+++ b/api/src/controllers/LectureController.ts
@@ -1,17 +1,6 @@
 import {Request} from 'express';
-import {
-  Authorized,
-  Body, CurrentUser,
-  Delete, ForbiddenError,
-  Get,
-  JsonController,
-  NotFoundError,
-  Param,
-  Post,
-  Put,
-  Req,
-  UseBefore
-} from 'routing-controllers';
+import { Authorized, Body, CurrentUser, Delete, ForbiddenError, Get,
+  JsonController, NotFoundError, Param, Post, Put, Req, UseBefore } from 'routing-controllers';
 import passportJwtMiddleware from '../security/passportJwtMiddleware';
 
 import {Lecture} from '../models/Lecture';

--- a/api/test/integration/lecture.ts
+++ b/api/test/integration/lecture.ts
@@ -1,0 +1,41 @@
+import * as chai from 'chai';
+import {Server} from '../../src/server';
+import {FixtureLoader} from '../../fixtures/FixtureLoader';
+import {JwtUtils} from '../../src/security/JwtUtils';
+import {User} from '../../src/models/User';
+import {Course} from '../../src/models/Course';
+import {FixtureUtils} from '../../fixtures/FixtureUtils';
+import chaiHttp = require('chai-http');
+import {Lecture} from '../../src/models/Lecture';
+
+chai.use(chaiHttp);
+const should = chai.should();
+const app = new Server().app;
+const BASE_URL = '/api/lecture';
+const fixtureLoader = new FixtureLoader();
+
+describe('Lecture', () => {
+  // Before each test we reset the database
+  beforeEach(async () => {
+    await fixtureLoader.load();
+  });
+
+  describe(`DELETE ${BASE_URL}` , () => {
+    it('should delete a lecture by course admin', async () => {
+      const course = await FixtureUtils.getRandomCourseWithAllUnitTypes();
+      const lectureId = await course.lectures[0];
+      const courseAdmin = await  User.findOne({_id: course.courseAdmin});
+
+      const res = await chai.request(app)
+        .del(BASE_URL + '/' + lectureId)
+        .set('Cookie', `token=${JwtUtils.generateToken(courseAdmin)}`);
+
+      res.status.should.be.equal(200);
+      const courseWithDeletedLecture = await Course.findById(course._id);
+      courseWithDeletedLecture.lectures[0].should.not.be.equal(lectureId);
+      const deletedLecture = await Lecture.findById(lectureId);
+      should.not.exist(deletedLecture, 'Lecture still exists');
+    });
+  });
+
+});


### PR DESCRIPTION
## Description:
Refactoring of the deleteLecture Endpoint 

Closes #965 

## Improvements
- fixed typemismatch in deleteLecture
- use async await
- Authorization Check if user can change Course and delete unit


<!--
ATTENTION:
Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix.
-->
