### PR TITLE
UglifyJs => Terser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Update mongoose to 5.2.x. [#1004](https://github.com/geli-lms/geli/pull/1004)
 - Update contributors list. [#1007](https://github.com/geli-lms/geli/issues/1007)
+- Use `terser` instead of `uglify-js`. [#1018](https://github.com/geli-lms/geli/pull/1018) 
 
 ### Removed
 

--- a/app/webFrontend/package-lock.json
+++ b/app/webFrontend/package-lock.json
@@ -13321,6 +13321,31 @@
         "inherits": "2"
       }
     },
+    "terser": {
+      "version": "3.10.11",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-3.10.11.tgz",
+      "integrity": "sha512-iruZ7j14oBbRYJC5cP0/vTU7YOWjN+J1ZskEGoF78tFzXdkK2hbCL/3TRZN8XB+MuvFhvOHMp7WkOCBO4VEL5g==",
+      "dev": true,
+      "requires": {
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.6"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",

--- a/app/webFrontend/package.json
+++ b/app/webFrontend/package.json
@@ -82,8 +82,12 @@
     "karma-jasmine": "^1.1.2",
     "karma-jasmine-html-reporter": "^1.2.0",
     "protractor": "^5.3.2",
+    "terser": "^3.10.11",
     "ts-node": "~5.0.1",
     "tslint": "~5.9.1",
     "typescript": "2.7.2"
+  },
+  "resolutions": {
+    "uglify-es": "npm:terser"
   }
 }


### PR DESCRIPTION
## Description:

https://github.com/angular/angular-cli/issues/5775#issuecomment-433013783

Build could be faster when terser (https://www.npmjs.com/package/terser) is used instead of uglify-js. 

**Uglify-Js**

![image](https://user-images.githubusercontent.com/3902676/48587510-b4c1be00-e933-11e8-99a5-ebcca073ee60.png)

**Terser**
![image](https://user-images.githubusercontent.com/3902676/48587505-a83d6580-e933-11e8-808a-1c74df19fe40.png)


## Improvements
- Faster build
