### PR TITLE
Read DB_PORT from env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Styles for free text units. [#867](https://github.com/geli-lms/geli/issues/867)
 - Export PDF with styled free text units. [#997](https://github.com/geli-lms/geli/issues/997)
 - Course-view-navigation for edit-users. [#924](https://github.com/geli-lms/geli/issues/924)
+- Make MongoDB port configurable `DB_PORT`. [#1034](https://github.com/geli-lms/geli/pull/1034)
 
 ### Changed
 - Update mongoose to 5.2.x. [#1004](https://github.com/geli-lms/geli/pull/1004)

--- a/api/src/config/main.ts
+++ b/api/src/config/main.ts
@@ -8,7 +8,7 @@ export default {
   baseurl: process.env.BASEURL || 'http://localhost:4200',
 
   // Database connection information
-  database: `mongodb://${process.env.DB_HOST || 'localhost'}:27017/${process.env.DB_NAME || 'geli'}`,
+  database: `mongodb://${process.env.DB_HOST || 'localhost'}:${process.env.DB_PORT || '27017'}/${process.env.DB_NAME || 'geli'}`,
 
   // Setting port for server
   port: process.env.PORT || 3030,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,10 +7,11 @@ The API can be configured using the following environment variables.
 | Variable | Description | Example value |
 | --- | --- | --- |
 | `BASEURL` | The URL you are hosting the web frontend at. This is used inside of e-mails. | `https://geli.fbi.h-da.de` |
-| `DB_HOST` | The host your MongoDB instance is running on (port `27017`) | `localhost` |
+| `DB_HOST` | The host your MongoDB instance is running on | `localhost` |
+| `DB_PORT` | The port your MongoDB instance is listening on | `27017` |
 | `MAILPROVIDER` | Use this when you are not using SMTP. Available providers are listed [here](https://nodemailer.com/smtp/well-known/)  | `DebugMail` |
 | `MAILSMTPSERVER` | The host your SMTP server is running on | `localhost` |
-| `MAILSMTPPORT` | The port your SMTP server ist listening on | `25` |
+| `MAILSMTPPORT` | The port your SMTP server is listening on | `25` |
 | `MAILUSER` | The username for your e-mail service | - |
 | `MAILPASS` | The password for your e-mail service | - |
 | `MAILSENDER` | The sender e-mail address the API should use | `no-reply@geli.edu` |


### PR DESCRIPTION
## Description:

I'm running mongodb on `27018` because `27017` is already in use. If this patch is applied you can use another port for mongodb by setting `DB_PORT`.

## Improvements
- Read `DB_PORT` from env

