### PR TITLE
Bugfix/#1039 ExportController teacher authorization vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Chat system access denial unit tests. [#989](https://github.com/geli-lms/geli/issues/989)
 - `DuplicationController` access denial unit tests. [#1016](https://github.com/geli-lms/geli/issues/1016)
+- `ExportController` access denial unit tests. [#1039](https://github.com/geli-lms/geli/issues/1039)
 - `TestHelper` class for shared API unit test functionality. [#989](https://github.com/geli-lms/geli/issues/989) [#1016](https://github.com/geli-lms/geli/issues/1016)
 - `extractSingleMongoId` variant of the `ExtractMongoId` utility function(s). [#989](https://github.com/geli-lms/geli/issues/989)
 - Show message count for unit chat. [#933](https://github.com/geli-lms/geli/issues/993)
@@ -21,12 +22,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Export PDF with styled free text units. [#997](https://github.com/geli-lms/geli/issues/997)
 - Course-view-navigation for edit-users. [#924](https://github.com/geli-lms/geli/issues/924)
 - Make MongoDB port configurable `DB_PORT`. [#1034](https://github.com/geli-lms/geli/pull/1034)
+- `IUserPrivileges`, `IUserEditPrivileges`, `ICourseUserPrivileges`, i.a. for the `checkPrivileges` methods. [#1039](https://github.com/geli-lms/geli/issues/1039)
 
 ### Changed
 - Update mongoose to 5.2.x. [#1004](https://github.com/geli-lms/geli/pull/1004)
 - Update contributors list. [#1007](https://github.com/geli-lms/geli/issues/1007)
 - Use `terser` instead of `uglify-js`. [#1018](https://github.com/geli-lms/geli/pull/1018)
-- `ExtractMongoId` utility upgrades & streamlining. [#989](https://github.com/geli-lms/geli/issues/989) [#1016](https://github.com/geli-lms/geli/issues/1016)
+- `ExtractMongoId` utility upgrades & streamlining. [#989](https://github.com/geli-lms/geli/issues/989) [#1016](https://github.com/geli-lms/geli/issues/1016) [#1039](https://github.com/geli-lms/geli/issues/1039)
 
 ### Removed
 - Export PDF with styled free text units. [#997](https://github.com/geli-lms/geli/issues/997)
@@ -41,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 - Fixed multiple severe security issues of the chat system. [#989](https://github.com/geli-lms/geli/issues/989)
 - Fixed multiple security issues of the three `DuplicationController` routes. [#1016](https://github.com/geli-lms/geli/issues/1016)
+- Fixed missing `teacher` authorization checks in the `ExportController` `course`/`lecture`/`unit` routes. [#1039](https://github.com/geli-lms/geli/issues/1039)
 - Update `node` to latest lts. [#1019](https://github.com/geli-lms/geli/issues/1019)
 
 ## [[0.8.2](https://github.com/geli-lms/geli/releases/tag/v0.8.2)] - 2018-11-08 - WS 18/19 🍪-Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `DuplicationController` access denial unit tests. [#1016](https://github.com/geli-lms/geli/issues/1016)
 - `ExportController` access denial unit tests. [#1039](https://github.com/geli-lms/geli/issues/1039)
 - `ExportController` 404 unit tests. [#1039](https://github.com/geli-lms/geli/issues/1039)
+- `DuplicationController` 404 unit tests. [#1039](https://github.com/geli-lms/geli/issues/1039)
 - `TestHelper` class for shared API unit test functionality. [#989](https://github.com/geli-lms/geli/issues/989) [#1016](https://github.com/geli-lms/geli/issues/1016)
 - `extractSingleMongoId` variant of the `ExtractMongoId` utility function(s). [#989](https://github.com/geli-lms/geli/issues/989)
 - Show message count for unit chat. [#933](https://github.com/geli-lms/geli/issues/993)
@@ -41,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Unnecessarily verbose `DuplicationController` route responses. [#1016](https://github.com/geli-lms/geli/issues/1016)
 - Prepare mongoose update. [#1003](https://github.com/geli-lms/geli/issues/1003) [#1027](https://github.com/geli-lms/geli/pull/1027)
 - `ExportController` missing 404 handling. [#1039](https://github.com/geli-lms/geli/issues/1039)
+- `DuplicationController` missing 404 handling. [#1039](https://github.com/geli-lms/geli/issues/1039)
 
 ### Security
 - Fixed multiple severe security issues of the chat system. [#989](https://github.com/geli-lms/geli/issues/989)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Chat system access denial unit tests. [#989](https://github.com/geli-lms/geli/issues/989)
 - `DuplicationController` access denial unit tests. [#1016](https://github.com/geli-lms/geli/issues/1016)
 - `ExportController` access denial unit tests. [#1039](https://github.com/geli-lms/geli/issues/1039)
+- `ExportController` 404 unit tests. [#1039](https://github.com/geli-lms/geli/issues/1039)
 - `TestHelper` class for shared API unit test functionality. [#989](https://github.com/geli-lms/geli/issues/989) [#1016](https://github.com/geli-lms/geli/issues/1016)
 - `extractSingleMongoId` variant of the `ExtractMongoId` utility function(s). [#989](https://github.com/geli-lms/geli/issues/989)
 - Show message count for unit chat. [#933](https://github.com/geli-lms/geli/issues/993)
@@ -39,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nondeterministic chat system unit test authorization failures. [#989](https://github.com/geli-lms/geli/issues/989)
 - Unnecessarily verbose `DuplicationController` route responses. [#1016](https://github.com/geli-lms/geli/issues/1016)
 - Prepare mongoose update. [#1003](https://github.com/geli-lms/geli/issues/1003) [#1027](https://github.com/geli-lms/geli/pull/1027)
+- `ExportController` missing 404 handling. [#1039](https://github.com/geli-lms/geli/issues/1039)
 
 ### Security
 - Fixed multiple severe security issues of the chat system. [#989](https://github.com/geli-lms/geli/issues/989)

--- a/api/fixtures/FixtureUtils.ts
+++ b/api/fixtures/FixtureUtils.ts
@@ -149,6 +149,15 @@ export class FixtureUtils {
     return Unit.findById(unitId);
   }
 
+  public static async getRandomUnitFromCourse(course: ICourse, hash?: string): Promise<IUnit> {
+    let units: Array<IUnit> = [];
+    for (const lecture of course.lectures) {
+      units = units.concat(lecture.units);
+    }
+    const unitId = await this.getRandom<IUnit>(units, hash);
+    return Unit.findById(unitId);
+  }
+
   /**
    * Provides simple shared setup functionality currently used by multiple chat system unit tests.
    *
@@ -160,15 +169,6 @@ export class FixtureUtils {
     const room = await FixtureUtils.getRandom<IChatRoom>(course.chatRooms, hash);
     const roomId = extractSingleMongoId(room);
     return {course, roomId};
-  }
-
-  public static async getRandomUnitFromCourse(course: ICourse, hash?: string): Promise<IUnit> {
-    let units: Array<IUnit> = [];
-    for (const lecture of course.lectures) {
-      units = units.concat(lecture.units);
-    }
-    const unitId = await this.getRandom<IUnit>(units, hash);
-    return Unit.findById(unitId);
   }
 
   private static async getAdmins(): Promise<IUser[]> {

--- a/api/fixtures/FixtureUtils.ts
+++ b/api/fixtures/FixtureUtils.ts
@@ -150,12 +150,8 @@ export class FixtureUtils {
   }
 
   public static async getRandomUnitFromCourse(course: ICourse, hash?: string): Promise<IUnit> {
-    let units: Array<IUnit> = [];
-    for (const lecture of course.lectures) {
-      units = units.concat(lecture.units);
-    }
-    const unitId = await this.getRandom<IUnit>(units, hash);
-    return Unit.findById(unitId);
+    const units = await Unit.find({_course: course});
+    return await this.getRandom<IUnit>(units, hash);
   }
 
   /**

--- a/api/fixtures/FixtureUtils.ts
+++ b/api/fixtures/FixtureUtils.ts
@@ -2,7 +2,7 @@ import {User} from '../src/models/User';
 import {Course, ICourseModel} from '../src/models/Course';
 import {IUserModel} from '../src/models/User';
 import {Lecture} from '../src/models/Lecture';
-import {Unit} from '../src/models/units/Unit';
+import {Unit, IUnitModel} from '../src/models/units/Unit';
 import {ICourse} from '../../shared/models/ICourse';
 import {ILecture} from '../../shared/models/ILecture';
 import {IUnit} from '../../shared/models/units/IUnit';
@@ -139,9 +139,9 @@ export class FixtureUtils {
     return Lecture.findOne({units: { $in: [ unit._id ] }});
   }
 
-  public static async getRandomUnit(hash?: string): Promise<IUnit> {
+  public static async getRandomUnit(hash?: string): Promise<IUnitModel> {
     const array = await this.getUnits();
-    return this.getRandom<IUnit>(array, hash);
+    return this.getRandom<IUnitModel>(array, hash);
   }
 
   public static async getRandomUnitFromLecture(lecture: ILecture, hash?: string): Promise<IUnit> {
@@ -149,9 +149,9 @@ export class FixtureUtils {
     return Unit.findById(unitId);
   }
 
-  public static async getRandomUnitFromCourse(course: ICourse, hash?: string): Promise<IUnit> {
+  public static async getRandomUnitFromCourse(course: ICourse, hash?: string): Promise<IUnitModel> {
     const units = await Unit.find({_course: course});
-    return await this.getRandom<IUnit>(units, hash);
+    return await this.getRandom<IUnitModel>(units, hash);
   }
 
   /**
@@ -193,7 +193,7 @@ export class FixtureUtils {
     return Lecture.find();
   }
 
-  public static async getUnits(): Promise<IUnit[]> {
+  public static async getUnits(): Promise<IUnitModel[]> {
     return Unit.find();
   }
 

--- a/api/src/config/errorCodes.ts
+++ b/api/src/config/errorCodes.ts
@@ -14,18 +14,6 @@ export const errorCodes = {
     }
   },
   duplication: {
-    courseDuplicationFailed: {
-      code: 'Course duplication failed',
-      text: 'Failed to duplicate course',
-    },
-    lectureDuplicationFailed: {
-      code: 'Lecture duplication failed',
-      text: 'Failed to duplicate lecture',
-    },
-    unitDuplicationFailed: {
-      code: 'Unit duplication failed',
-      text: 'Failed to duplicate unit',
-    },
     targetNotFound: {
       code: 'Target notfound',
       text: 'The specified duplication target could not be found',

--- a/api/src/config/errorCodes.ts
+++ b/api/src/config/errorCodes.ts
@@ -25,6 +25,10 @@ export const errorCodes = {
     unitDuplicationFailed: {
       code: 'Unit duplication failed',
       text: 'Failed to duplicate unit',
+    },
+    targetNotFound: {
+      code: 'Target notfound',
+      text: 'The specified duplication target could not be found',
     }
   },
   mail: {

--- a/api/src/controllers/DuplicationController.ts
+++ b/api/src/controllers/DuplicationController.ts
@@ -47,8 +47,6 @@ export class DuplicationController {
    *     {
    *         "_id": "5ab19c382ac32e46dcaa1574"
    *     }
-   *
-   * @apiError InternalServerError Failed to duplicate course
    */
   @Post('/course/:id')
   async duplicateCourse(@Param('id') id: string,
@@ -83,8 +81,6 @@ export class DuplicationController {
    *     {
    *         "_id": "5ab1a218dab93c34f8541e25"
    *     }
-   *
-   * @apiError InternalServerError Failed to duplicate lecture
    */
   @Post('/lecture/:id')
   async duplicateLecture(@Param('id') id: string,
@@ -119,8 +115,6 @@ export class DuplicationController {
    *     {
    *         "_id": "5ab1a380f5bbeb423070d787"
    *     }
-   *
-   * @apiError InternalServerError Failed to duplicate unit
    */
   @Post('/unit/:id')
   async duplicateUnit(@Param('id') id: string,

--- a/api/src/controllers/DuplicationController.ts
+++ b/api/src/controllers/DuplicationController.ts
@@ -47,6 +47,9 @@ export class DuplicationController {
    *     {
    *         "_id": "5ab19c382ac32e46dcaa1574"
    *     }
+   *
+   * @apiError NotFoundError If the course couldn't be found.
+   * @apiError ForbiddenError assertUserDuplicationAuthorization check failed.
    */
   @Post('/course/:id')
   async duplicateCourse(@Param('id') id: string,
@@ -81,6 +84,9 @@ export class DuplicationController {
    *     {
    *         "_id": "5ab1a218dab93c34f8541e25"
    *     }
+   *
+   * @apiError NotFoundError If the lecture or the target courseId couldn't be found.
+   * @apiError ForbiddenError assertUserDuplicationAuthorization check failed.
    */
   @Post('/lecture/:id')
   async duplicateLecture(@Param('id') id: string,
@@ -115,6 +121,9 @@ export class DuplicationController {
    *     {
    *         "_id": "5ab1a380f5bbeb423070d787"
    *     }
+   *
+   * @apiError NotFoundError If the unit or the target lectureId couldn't be found.
+   * @apiError ForbiddenError assertUserDuplicationAuthorization check failed.
    */
   @Post('/unit/:id')
   async duplicateUnit(@Param('id') id: string,

--- a/api/src/controllers/DuplicationController.ts
+++ b/api/src/controllers/DuplicationController.ts
@@ -76,7 +76,7 @@ export class DuplicationController {
    * @apiPermission admin
    *
    * @apiParam {String} id Lecture ID.
-   * @apiParam {Object} data Lecture data (with courseId).
+   * @apiParam {Object} data Object with target courseId (the lecture duplicate will be attached to this course).
    *
    * @apiSuccess {Lecture} lecture Duplicated lecture ID.
    *

--- a/api/src/controllers/DuplicationController.ts
+++ b/api/src/controllers/DuplicationController.ts
@@ -55,9 +55,7 @@ export class DuplicationController {
                         @BodyParam('courseAdmin', {required: false}) newCourseAdminId: string,
                         @CurrentUser() currentUser: IUser) {
     const courseModel: ICourseModel = await Course.findById(id);
-    if (!courseModel) {
-      throw new NotFoundError();
-    }
+    if (!courseModel) { throw new NotFoundError(); }
     await DuplicationController.assertUserDuplicationAuthorization(currentUser, courseModel);
 
     // Set the currentUser's id as newCourseAdminId if it wasn't specified by the request.
@@ -93,14 +91,10 @@ export class DuplicationController {
                          @BodyParam('courseId', {required: true}) targetCourseId: string,
                          @CurrentUser() currentUser: IUser) {
     const course = await Course.findOne({lectures: id});
-    if (!course) {
-      throw new NotFoundError();
-    }
+    if (!course) { throw new NotFoundError(); }
     await DuplicationController.assertUserDuplicationAuthorization(currentUser, course);
     const targetCourse = await Course.findById(targetCourseId);
-    if (!targetCourse) {
-      throw new NotFoundError(errorCodes.duplication.targetNotFound.text);
-    }
+    if (!targetCourse) { throw new NotFoundError(errorCodes.duplication.targetNotFound.text); }
     await DuplicationController.assertUserDuplicationAuthorization(currentUser, targetCourse);
 
     const lectureModel: ILectureModel = await Lecture.findById(id);
@@ -133,15 +127,11 @@ export class DuplicationController {
                       @BodyParam('lectureId', {required: true}) targetLectureId: string,
                       @CurrentUser() currentUser: IUser) {
     const unitModel: IUnitModel = await Unit.findById(id);
-    if (!unitModel) {
-      throw new NotFoundError();
-    }
+    if (!unitModel) { throw new NotFoundError(); }
     const course = await Course.findById(unitModel._course);
     await DuplicationController.assertUserDuplicationAuthorization(currentUser, course);
     const targetCourse = await Course.findOne({lectures: targetLectureId});
-    if (!targetCourse) {
-      throw new NotFoundError(errorCodes.duplication.targetNotFound.text);
-    }
+    if (!targetCourse) { throw new NotFoundError(errorCodes.duplication.targetNotFound.text); }
     await DuplicationController.assertUserDuplicationAuthorization(currentUser, targetCourse);
     const targetCourseId = extractSingleMongoId(targetCourse);
 

--- a/api/src/controllers/DuplicationController.ts
+++ b/api/src/controllers/DuplicationController.ts
@@ -1,7 +1,4 @@
-import {
-  BodyParam, Post, Param, JsonController, UseBefore, Authorized, CurrentUser,
-  InternalServerError, ForbiddenError
-} from 'routing-controllers';
+import {BodyParam, Post, Param, JsonController, UseBefore, Authorized, CurrentUser, ForbiddenError} from 'routing-controllers';
 import passportJwtMiddleware from '../security/passportJwtMiddleware';
 import {IUser} from '../../../shared/models/IUser';
 import {IUnit} from '../../../shared/models/units/IUnit';
@@ -12,7 +9,6 @@ import {ILecture} from '../../../shared/models/ILecture';
 import {ICourse} from '../../../shared/models/ICourse';
 import {IDuplicationResponse} from '../../../shared/models/IDuplicationResponse';
 import {extractSingleMongoId} from '../utilities/ExtractMongoId';
-import {errorCodes} from '../config/errorCodes';
 
 
 @JsonController('/duplicate')

--- a/api/src/controllers/ExportController.ts
+++ b/api/src/controllers/ExportController.ts
@@ -99,8 +99,12 @@ export class ExportController {
    *     }
    */
   @Get('/unit/:id')
-  async exportUnit(@Param('id') id: string) {
+  async exportUnit(@Param('id') id: string, @CurrentUser() currentUser: IUser) {
     const unit = await Unit.findById(id);
+    const course = await Course.findById(unit._course);
+    if (!course.checkPrivileges(currentUser).userCanEditCourse) {
+      throw new ForbiddenError();
+    }
     return unit.exportJSON();
   }
 

--- a/api/src/controllers/ExportController.ts
+++ b/api/src/controllers/ExportController.ts
@@ -1,4 +1,7 @@
-import {Authorized, CurrentUser, Get, JsonController, Param, UseBefore, ForbiddenError} from 'routing-controllers';
+import {
+  Authorized, CurrentUser, Get, JsonController, Param, UseBefore,
+  ForbiddenError, NotFoundError
+} from 'routing-controllers';
 import passportJwtMiddleware from '../security/passportJwtMiddleware';
 import {Course, ICourseModel} from '../models/Course';
 import {Lecture} from '../models/Lecture';
@@ -49,6 +52,9 @@ export class ExportController {
   @Get('/course/:id')
   async exportCourse(@Param('id') id: string, @CurrentUser() currentUser: IUser) {
     const course = await Course.findById(id);
+    if (!course) {
+      throw new NotFoundError();
+    }
     ExportController.assertUserExportAuthorization(currentUser, course);
     return course.exportJSON();
   }
@@ -73,9 +79,12 @@ export class ExportController {
    */
   @Get('/lecture/:id')
   async exportLecture(@Param('id') id: string, @CurrentUser() currentUser: IUser) {
+    const lecture = await Lecture.findById(id);
+    if (!lecture) {
+      throw new NotFoundError();
+    }
     const course = await Course.findOne({lectures: id});
     ExportController.assertUserExportAuthorization(currentUser, course);
-    const lecture = await Lecture.findById(id);
     return lecture.exportJSON();
   }
 
@@ -103,6 +112,9 @@ export class ExportController {
   @Get('/unit/:id')
   async exportUnit(@Param('id') id: string, @CurrentUser() currentUser: IUser) {
     const unit = await Unit.findById(id);
+    if (!unit) {
+      throw new NotFoundError();
+    }
     const course = await Course.findById(unit._course);
     ExportController.assertUserExportAuthorization(currentUser, course);
     return unit.exportJSON();

--- a/api/src/controllers/ExportController.ts
+++ b/api/src/controllers/ExportController.ts
@@ -1,4 +1,4 @@
-import {Authorized, CurrentUser, Get, JsonController, Param, UseBefore} from 'routing-controllers';
+import {Authorized, CurrentUser, Get, JsonController, Param, UseBefore, ForbiddenError} from 'routing-controllers';
 import passportJwtMiddleware from '../security/passportJwtMiddleware';
 import {Course} from '../models/Course';
 import {Lecture} from '../models/Lecture';
@@ -41,8 +41,11 @@ export class ExportController {
    *     }
    */
   @Get('/course/:id')
-  async exportCourse(@Param('id') id: string) {
+  async exportCourse(@Param('id') id: string, @CurrentUser() currentUser: IUser) {
     const course = await Course.findById(id);
+    if (!course.checkPrivileges(currentUser).userCanEditCourse) {
+      throw new ForbiddenError();
+    }
     return course.exportJSON();
   }
 

--- a/api/src/controllers/ExportController.ts
+++ b/api/src/controllers/ExportController.ts
@@ -48,6 +48,9 @@ export class ExportController {
    *         }],
    *         "hasAccessKey": false
    *     }
+   *
+   * @apiError NotFoundError If the course couldn't be found.
+   * @apiError ForbiddenError assertUserExportAuthorization check.
    */
   @Get('/course/:id')
   async exportCourse(@Param('id') id: string, @CurrentUser() currentUser: IUser) {
@@ -76,6 +79,9 @@ export class ExportController {
    *         "description": "Some lecture desc",
    *         "units": []
    *     }
+   *
+   * @apiError NotFoundError If the lecture couldn't be found.
+   * @apiError ForbiddenError assertUserExportAuthorization check.
    */
   @Get('/lecture/:id')
   async exportLecture(@Param('id') id: string, @CurrentUser() currentUser: IUser) {
@@ -108,6 +114,9 @@ export class ExportController {
    *         "markdown": "Welcome, this is the start",
    *         "__t": "free-text"
    *     }
+   *
+   * @apiError NotFoundError If the unit couldn't be found.
+   * @apiError ForbiddenError assertUserExportAuthorization check.
    */
   @Get('/unit/:id')
   async exportUnit(@Param('id') id: string, @CurrentUser() currentUser: IUser) {

--- a/api/src/controllers/ExportController.ts
+++ b/api/src/controllers/ExportController.ts
@@ -68,7 +68,11 @@ export class ExportController {
    *     }
    */
   @Get('/lecture/:id')
-  async exportLecture(@Param('id') id: string) {
+  async exportLecture(@Param('id') id: string, @CurrentUser() currentUser: IUser) {
+    const course = await Course.findOne({lectures: id});
+    if (!course.checkPrivileges(currentUser).userCanEditCourse) {
+      throw new ForbiddenError();
+    }
     const lecture = await Lecture.findById(id);
     return lecture.exportJSON();
   }

--- a/api/src/controllers/ExportController.ts
+++ b/api/src/controllers/ExportController.ts
@@ -50,7 +50,7 @@ export class ExportController {
    *     }
    *
    * @apiError NotFoundError If the course couldn't be found.
-   * @apiError ForbiddenError assertUserExportAuthorization check.
+   * @apiError ForbiddenError assertUserExportAuthorization check failed.
    */
   @Get('/course/:id')
   async exportCourse(@Param('id') id: string, @CurrentUser() currentUser: IUser) {
@@ -81,7 +81,7 @@ export class ExportController {
    *     }
    *
    * @apiError NotFoundError If the lecture couldn't be found.
-   * @apiError ForbiddenError assertUserExportAuthorization check.
+   * @apiError ForbiddenError assertUserExportAuthorization check failed.
    */
   @Get('/lecture/:id')
   async exportLecture(@Param('id') id: string, @CurrentUser() currentUser: IUser) {
@@ -116,7 +116,7 @@ export class ExportController {
    *     }
    *
    * @apiError NotFoundError If the unit couldn't be found.
-   * @apiError ForbiddenError assertUserExportAuthorization check.
+   * @apiError ForbiddenError assertUserExportAuthorization check failed.
    */
   @Get('/unit/:id')
   async exportUnit(@Param('id') id: string, @CurrentUser() currentUser: IUser) {

--- a/api/src/models/Course.ts
+++ b/api/src/models/Course.ts
@@ -2,22 +2,33 @@ import {ICourse} from '../../../shared/models/ICourse';
 import {ICourseDashboard} from '../../../shared/models/ICourseDashboard';
 import {ICourseView} from '../../../shared/models/ICourseView';
 import * as mongoose from 'mongoose';
-import {User, IUserModel} from './User';
+import {User, IUserModel, IUserPrivileges} from './User';
 import {ILectureModel, Lecture} from './Lecture';
 import {ILecture} from '../../../shared/models/ILecture';
 import {InternalServerError} from 'routing-controllers';
 import {IUser} from '../../../shared/models/IUser';
 import {ObjectID} from 'bson';
 import {Directory} from './mediaManager/Directory';
-import {IFlags} from '../../../shared/models/IFlags';
 import {extractSingleMongoId} from '../utilities/ExtractMongoId';
 import {ChatRoom, IChatRoomModel} from './ChatRoom';
 
 import {Picture} from './mediaManager/File';
 
+
+export interface ICourseUserPrivileges extends IUserPrivileges {
+  userIsAdmin: boolean;
+  courseAdminId: string;
+  userIsCourseAdmin: boolean;
+  userIsCourseTeacher: boolean;
+  userIsCourseStudent: boolean;
+  userIsCourseMember: boolean;
+  userCanEditCourse: boolean;
+  userCanViewCourse: boolean;
+}
+
 interface ICourseModel extends ICourse, mongoose.Document {
   exportJSON: (sanitize?: boolean, onlyBasicData?: boolean) => Promise<ICourse>;
-  checkPrivileges: (user: IUser) => IFlags;
+  checkPrivileges: (user: IUser) => ICourseUserPrivileges;
   forDashboard: (user: IUser) => ICourseDashboard;
   forView: (user: IUser) => ICourseView;
   populateLecturesFor: (user: IUser) => this;
@@ -276,7 +287,7 @@ courseSchema.statics.changeCourseAdminFromUser = async function (userFrom: IUser
   return Course.updateMany({courseAdmin: userFrom._id}, {courseAdmin: userTo._id});
 };
 
-courseSchema.methods.checkPrivileges = function (user: IUser) {
+courseSchema.methods.checkPrivileges = function (user: IUser): ICourseUserPrivileges {
   const {userIsAdmin, ...userIs} = User.checkPrivileges(user);
   const userId = extractSingleMongoId(user);
 

--- a/api/src/models/Course.ts
+++ b/api/src/models/Course.ts
@@ -16,7 +16,6 @@ import {Picture} from './mediaManager/File';
 
 
 export interface ICourseUserPrivileges extends IUserPrivileges {
-  userIsAdmin: boolean;
   courseAdminId: string;
   userIsCourseAdmin: boolean;
   userIsCourseTeacher: boolean;

--- a/api/src/utilities/ExtractMongoId.ts
+++ b/api/src/utilities/ExtractMongoId.ts
@@ -8,7 +8,7 @@
  * @param from A mongoose object or ID string.
  * @param fallback Return this if no apparent ID is found.
  */
-export function extractSingleMongoId<T>(from: any, fallback?: T): string | T {
+export function extractSingleMongoId<T = undefined>(from: any, fallback?: T): string | T {
   if (typeof from === 'string' || from instanceof String) {
     return from.toString();
   } else if (from instanceof Object) {
@@ -35,7 +35,7 @@ export function extractSingleMongoId<T>(from: any, fallback?: T): string | T {
  * @param from A mongoose object, ID string, or (possibly mixed) array of such.
  * @param fallback Return this if no apparent ID is found.
  */
-export function extractMongoId<T>(from: any | any[], fallback?: T): string | T | (string | T)[] {
+export function extractMongoId<T = undefined>(from: any | any[], fallback?: T): string | T | (string | T)[] {
   if (Array.isArray(from)) {
     const results: any[] = [];
     for (const value of from) {

--- a/api/test/controllers/duplicate.ts
+++ b/api/test/controllers/duplicate.ts
@@ -28,6 +28,14 @@ const should = chai.should();
 const BASE_URL = '/api/duplicate';
 const testHelper = new TestHelper(BASE_URL);
 
+/**
+ * Provides simple shared setup functionality currently used by the duplicate access denial unit tests.
+ * It finds a targetCourse (ICourseModel) that doesn't share any of the teachers with the given input course.
+ * Then it finds the courseAdmin (IUserModel; assumed to be a teacher) of that targetCourse and returns both.
+ *
+ * @param course The course for which the "unauthorized teacher set" is to be generated.
+ * @returns An object with the targetCourse and unauthorizedTeacher.
+ */
 async function prepareUnauthorizedTeacherSetFor(course: ICourse) {
   const authorizedTeachers = [course.courseAdmin, ...course.teachers];
   const targetCourse = await Course.findOne({
@@ -38,13 +46,21 @@ async function prepareUnauthorizedTeacherSetFor(course: ICourse) {
   return {targetCourse, unauthorizedTeacher};
 }
 
+/**
+ * Provides simple shared setup functionality currently used by the duplicate access denial unit tests.
+ * It first gets a random teacher for the input course.
+ * Then it finds a targetCourse (ICourseModel) for that teacher.
+ *
+ * @param course The course for which the "other course set" is to be generated.
+ * @returns An object with the targetCourse and teacher.
+ */
 async function prepareOtherTargetCourseSetFor(course: ICourse) {
   const teacher = await FixtureUtils.getRandomTeacherForCourse(course);
   const targetCourse = await Course.findOne({
     courseAdmin: {$ne: teacher},
     teachers: {$ne: teacher}
   });
-  return {teacher, targetCourse};
+  return {targetCourse, teacher};
 }
 
 async function testForbidden(user: IUser, urlPostfix = '', sendData: object) {

--- a/api/test/controllers/duplicate.ts
+++ b/api/test/controllers/duplicate.ts
@@ -7,7 +7,6 @@ import {ILecture} from '../../../shared/models/ILecture';
 import {IUnit} from '../../../shared/models/units/IUnit';
 import * as util from 'util';
 import {Course} from '../../src/models/Course';
-import {User} from '../../src/models/User';
 import {IUser} from '../../../shared/models/IUser';
 import {ICodeKataModel} from '../../src/models/units/CodeKataUnit';
 import {IFreeTextUnit} from '../../../shared/models/units/IFreeTextUnit';
@@ -229,6 +228,40 @@ describe('Duplicate', async () => {
       const course = await FixtureUtils.getCourseFromLecture(lecture);
       const {teacher, targetCourse} = await prepareOtherTargetCourseSetFor(course);
       await testForbidden(teacher, `/lecture/${lecture._id}`, {courseId: targetCourse._id});
+    });
+
+    it('should respond with 404 for a unit id that doesn\'t exist', async () => {
+      const admin = await FixtureUtils.getRandomAdmin();
+      const targetLecture = await FixtureUtils.getRandomLecture();
+      const result = await testHelper.commonUserPostRequest(admin, '/unit/000000000000000000000000', {lectureId: targetLecture._id});
+      result.status.should.be.equal(404);
+    });
+
+    it('should respond with 404 for a lecture id that doesn\'t exist', async () => {
+      const admin = await FixtureUtils.getRandomAdmin();
+      const targetCourse = await FixtureUtils.getRandomCourse();
+      const result = await testHelper.commonUserPostRequest(admin, '/lecture/000000000000000000000000', {courseId: targetCourse._id});
+      result.status.should.be.equal(404);
+    });
+
+    it('should respond with 404 for a course id that doesn\'t exist', async () => {
+      const admin = await FixtureUtils.getRandomAdmin();
+      const result = await testHelper.commonUserPostRequest(admin, '/course/000000000000000000000000');
+      result.status.should.be.equal(404);
+    });
+
+    it('should respond with 404 for a target lecture id that doesn\'t exist (unit duplication)', async () => {
+      const admin = await FixtureUtils.getRandomAdmin();
+      const unit = await FixtureUtils.getRandomUnit();
+      const result = await testHelper.commonUserPostRequest(admin, `/unit/${unit._id}`, {lectureId: '000000000000000000000000'});
+      result.status.should.be.equal(404);
+    });
+
+    it('should respond with 404 for a target course id that doesn\'t exist (lecture duplication)', async () => {
+      const admin = await FixtureUtils.getRandomAdmin();
+      const lecture = await FixtureUtils.getRandomLecture();
+      const result = await testHelper.commonUserPostRequest(admin, `/lecture/${lecture._id}`, {courseId: '000000000000000000000000'});
+      result.status.should.be.equal(404);
     });
   });
 });

--- a/api/test/controllers/duplicate.ts
+++ b/api/test/controllers/duplicate.ts
@@ -75,6 +75,12 @@ async function testSuccess(user: IUser, urlPostfix = '', sendData: object, error
   return response.body._id;
 }
 
+async function testNotFound(what: string, sendData?: string | object) {
+  const admin = await FixtureUtils.getRandomAdmin();
+  const result = await testHelper.commonUserPostRequest(admin, `/${what}/000000000000000000000000`, sendData);
+  result.status.should.be.equal(404);
+}
+
 describe('Duplicate', async () => {
   beforeEach(async () => {
     await testHelper.resetForNextTest();
@@ -231,37 +237,27 @@ describe('Duplicate', async () => {
     });
 
     it('should respond with 404 for a unit id that doesn\'t exist', async () => {
-      const admin = await FixtureUtils.getRandomAdmin();
       const targetLecture = await FixtureUtils.getRandomLecture();
-      const result = await testHelper.commonUserPostRequest(admin, '/unit/000000000000000000000000', {lectureId: targetLecture._id});
-      result.status.should.be.equal(404);
+      testNotFound('/unit/000000000000000000000000', {lectureId: targetLecture._id});
     });
 
     it('should respond with 404 for a lecture id that doesn\'t exist', async () => {
-      const admin = await FixtureUtils.getRandomAdmin();
       const targetCourse = await FixtureUtils.getRandomCourse();
-      const result = await testHelper.commonUserPostRequest(admin, '/lecture/000000000000000000000000', {courseId: targetCourse._id});
-      result.status.should.be.equal(404);
+      testNotFound('/lecture/000000000000000000000000', {courseId: targetCourse._id});
     });
 
     it('should respond with 404 for a course id that doesn\'t exist', async () => {
-      const admin = await FixtureUtils.getRandomAdmin();
-      const result = await testHelper.commonUserPostRequest(admin, '/course/000000000000000000000000');
-      result.status.should.be.equal(404);
+      testNotFound('/course/000000000000000000000000');
     });
 
     it('should respond with 404 for a target lecture id that doesn\'t exist (unit duplication)', async () => {
-      const admin = await FixtureUtils.getRandomAdmin();
       const unit = await FixtureUtils.getRandomUnit();
-      const result = await testHelper.commonUserPostRequest(admin, `/unit/${unit._id}`, {lectureId: '000000000000000000000000'});
-      result.status.should.be.equal(404);
+      testNotFound(`/unit/${unit._id}`, {lectureId: '000000000000000000000000'});
     });
 
     it('should respond with 404 for a target course id that doesn\'t exist (lecture duplication)', async () => {
-      const admin = await FixtureUtils.getRandomAdmin();
       const lecture = await FixtureUtils.getRandomLecture();
-      const result = await testHelper.commonUserPostRequest(admin, `/lecture/${lecture._id}`, {courseId: '000000000000000000000000'});
-      result.status.should.be.equal(404);
+      testNotFound(`/lecture/${lecture._id}`, {courseId: '000000000000000000000000'});
     });
   });
 });

--- a/api/test/controllers/duplicate.ts
+++ b/api/test/controllers/duplicate.ts
@@ -29,9 +29,9 @@ const BASE_URL = '/api/duplicate';
 const testHelper = new TestHelper(BASE_URL);
 
 /**
- * Provides simple shared setup functionality currently used by the duplicate access denial unit tests.
+ * Provides simple shared setup functionality used by the duplicate access denial unit tests.
  * It finds a targetCourse (ICourseModel) that doesn't share any of the teachers with the given input course.
- * Then it finds the courseAdmin (IUserModel; assumed to be a teacher) of that targetCourse and returns both.
+ * Then it finds the unauthorizedTeacher, which is simply a random teacher of the targetCourse.
  *
  * @param course The course for which the "unauthorized teacher set" is to be generated.
  * @returns An object with the targetCourse and unauthorizedTeacher.
@@ -42,12 +42,12 @@ async function prepareUnauthorizedTeacherSetFor(course: ICourse) {
     courseAdmin: {$nin: authorizedTeachers},
     teachers: {$nin: authorizedTeachers}
   });
-  const unauthorizedTeacher = await User.findById(targetCourse.courseAdmin);
+  const unauthorizedTeacher = await FixtureUtils.getRandomTeacherForCourse(targetCourse);
   return {targetCourse, unauthorizedTeacher};
 }
 
 /**
- * Provides simple shared setup functionality currently used by the duplicate access denial unit tests.
+ * Provides simple shared setup functionality used by the duplicate access denial unit tests.
  * It first gets a random teacher for the input course.
  * Then it finds a targetCourse (ICourseModel) for that teacher.
  *

--- a/api/test/controllers/export.ts
+++ b/api/test/controllers/export.ts
@@ -4,7 +4,7 @@ import {TestHelper} from '../TestHelper';
 import {FixtureUtils} from '../../fixtures/FixtureUtils';
 import {Course} from '../../src/models/Course';
 import {ICourse} from '../../../shared/models/ICourse';
-import {User} from '../../src/models/User';
+import {User, IUserModel} from '../../src/models/User';
 import {Lecture} from '../../src/models/Lecture';
 import {ILecture} from '../../../shared/models/ILecture';
 import {IUnit} from '../../../shared/models/units/IUnit';
@@ -167,6 +167,24 @@ describe('Export', async () => {
       const {course, unauthorizedTeacher} = await exportAccessDenialSetup();
       const result = await testHelper.commonUserGetRequest(unauthorizedTeacher, `/course/${course._id}`);
       result.status.should.be.equal(403);
+    });
+
+    it('should respond with 404 for a unit id that doesn\'t exist', async () => {
+      const admin = await FixtureUtils.getRandomAdmin();
+      const result = await testHelper.commonUserGetRequest(admin, '/unit/000000000000000000000000');
+      result.status.should.be.equal(404);
+    });
+
+    it('should respond with 404 for a lecture id that doesn\'t exist', async () => {
+      const admin = await FixtureUtils.getRandomAdmin();
+      const result = await testHelper.commonUserGetRequest(admin, '/lecture/000000000000000000000000');
+      result.status.should.be.equal(404);
+    });
+
+    it('should respond with 404 for a course id that doesn\'t exist', async () => {
+      const admin = await FixtureUtils.getRandomAdmin();
+      const result = await testHelper.commonUserGetRequest(admin, '/course/000000000000000000000000');
+      result.status.should.be.equal(404);
     });
   });
 

--- a/api/test/controllers/export.ts
+++ b/api/test/controllers/export.ts
@@ -134,6 +134,38 @@ describe('Export', async () => {
         courseJson.lectures.should.be.instanceOf(Array).and.have.lengthOf(course.lectures.length);
       }
     });
+
+    it('should forbid unit export for an unauthorized teacher', async () => {
+      const course = await FixtureUtils.getRandomCourse();
+      const unit = await FixtureUtils.getRandomUnitFromCourse(course);
+      const unauthorizedTeacher = await User.findOne({
+        _id: {$nin: [course.courseAdmin, ...course.teachers]},
+        role: 'teacher'
+      });
+      const result = await testHelper.commonUserGetRequest(unauthorizedTeacher, `/unit/${unit._id}`);
+      result.status.should.be.equal(403);
+    });
+
+    it('should forbid lecture export for an unauthorized teacher', async () => {
+      const course = await FixtureUtils.getRandomCourse();
+      const lecture = await FixtureUtils.getRandomLectureFromCourse(course);
+      const unauthorizedTeacher = await User.findOne({
+        _id: {$nin: [course.courseAdmin, ...course.teachers]},
+        role: 'teacher'
+      });
+      const result = await testHelper.commonUserGetRequest(unauthorizedTeacher, `/lecture/${lecture._id}`);
+      result.status.should.be.equal(403);
+    });
+
+    it('should forbid course export for an unauthorized teacher', async () => {
+      const course = await FixtureUtils.getRandomCourse();
+      const unauthorizedTeacher = await User.findOne({
+        _id: {$nin: [course.courseAdmin, ...course.teachers]},
+        role: 'teacher'
+      });
+      const result = await testHelper.commonUserGetRequest(unauthorizedTeacher, `/course/${course._id}`);
+      result.status.should.be.equal(403);
+    });
   });
 
   describe(`GET ${BASE_URL}/user`, async () => {

--- a/api/test/controllers/export.ts
+++ b/api/test/controllers/export.ts
@@ -40,6 +40,12 @@ async function exportAccessDenialSetup() {
   return {course, unauthorizedTeacher};
 }
 
+async function testNotFound(what: string) {
+  const admin = await FixtureUtils.getRandomAdmin();
+  const result = await testHelper.commonUserGetRequest(admin, `/${what}/000000000000000000000000`);
+  result.status.should.be.equal(404);
+}
+
 describe('Export', async () => {
   beforeEach(async () => {
     await testHelper.resetForNextTest();
@@ -169,23 +175,9 @@ describe('Export', async () => {
       result.status.should.be.equal(403);
     });
 
-    it('should respond with 404 for a unit id that doesn\'t exist', async () => {
-      const admin = await FixtureUtils.getRandomAdmin();
-      const result = await testHelper.commonUserGetRequest(admin, '/unit/000000000000000000000000');
-      result.status.should.be.equal(404);
-    });
-
-    it('should respond with 404 for a lecture id that doesn\'t exist', async () => {
-      const admin = await FixtureUtils.getRandomAdmin();
-      const result = await testHelper.commonUserGetRequest(admin, '/lecture/000000000000000000000000');
-      result.status.should.be.equal(404);
-    });
-
-    it('should respond with 404 for a course id that doesn\'t exist', async () => {
-      const admin = await FixtureUtils.getRandomAdmin();
-      const result = await testHelper.commonUserGetRequest(admin, '/course/000000000000000000000000');
-      result.status.should.be.equal(404);
-    });
+    it('should respond with 404 for a unit id that doesn\'t exist', async () => await testNotFound('unit'));
+    it('should respond with 404 for a lecture id that doesn\'t exist', async () => await testNotFound('lecture'));
+    it('should respond with 404 for a course id that doesn\'t exist', async () => await testNotFound('course'));
   });
 
   describe(`GET ${BASE_URL}/user`, async () => {

--- a/api/test/controllers/export.ts
+++ b/api/test/controllers/export.ts
@@ -29,10 +29,10 @@ const testHelper = new TestHelper(BASE_URL);
 /**
  * Provides simple shared setup functionality used by the export access denial unit tests.
  *
- * @returns A course and an unauthorizedTeacher (i.e. a teacher that isn't part of the course).
+ * @returns A course with at least one unit/lecture and an unauthorizedTeacher (i.e. a teacher that isn't part of the course).
  */
 async function exportAccessDenialSetup() {
-  const course = await FixtureUtils.getRandomCourse();
+  const course = await FixtureUtils.getRandomCourseWithAllUnitTypes();
   const unauthorizedTeacher = await User.findOne({
     _id: {$nin: [course.courseAdmin, ...course.teachers]},
     role: 'teacher'

--- a/api/test/controllers/export.ts
+++ b/api/test/controllers/export.ts
@@ -167,7 +167,6 @@ describe('Export', async () => {
         text: 'blubba blubba'
       }).save();
 
-
       await new WhitelistUser({
         firstName: student.profile.firstName,
         lastName: student.profile.lastName,
@@ -184,7 +183,6 @@ describe('Export', async () => {
       const result = await testHelper.commonUserGetRequest(teacher, `/user`);
       expect(result).to.have.status(200);
     });
-
 
     it('should export admin data', async () => {
       const admin = await FixtureUtils.getRandomAdmin();


### PR DESCRIPTION
## Description:

Closes #1039

Secures the `ExportController ` by adding the missing `teacher` authorization checks to:
`{get} /api/export/course/:id`
`{get} /api/export/lecture/:id`
`{get} /api/export/unit/:id`

## Core improvements:
- Adds `teacher` authorization checks.
- Adds access denial unit tests _(to ensure that the `teacher` authorization checks work)_.
- Adds 404 checks to the `ExportController` routes.
- Adds `ExportController` 404 unit tests.

## Opportunistic improvements:
- Adds `IUserPrivileges`, `IUserEditPrivileges`, `ICourseUserPrivileges` for the `checkPrivileges`/`checkEditUser`/`checkEditableBy` methods.
- Adds comments to the `duplicate.ts` access denial unit test preparation functions.
- Fixes the generic parameter defaults of `ExtractMongoId`.
- Fixes the static `FixtureUtils` function `getRandomUnitFromCourse`.
- Refactor the export unit tests to use the `TestHelper`.
- Adds 404 checks to the `DuplicationController` routes.
- Adds `DuplicationController` 404 unit tests.
- _Other random minor refactoring._

## Known Issues:
_NONE_

<!--
ATTENTION:
Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix.
-->
