### PR TITLE
Bugfix/#1190 UnitController vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `UnitController` status code `403` (not authorized to view / edit course) unit tests for all routes. [#1190](https://github.com/geli-lms/geli/issues/1190)
 
 ### Changed
-- Extended `ProgressController` `PUT` route to handle both creation and updates. [#1116](https://github.com/geli-lms/geli/issues/1116)
-- Refactored `ProgressController` unit tests in general. [#1116](https://github.com/geli-lms/geli/issues/1116)
+- Extend `ProgressController` `PUT` route to handle both creation and updates. [#1116](https://github.com/geli-lms/geli/issues/1116)
+- Refactor `ProgressController` unit tests in general. [#1116](https://github.com/geli-lms/geli/issues/1116)
 - Instead of a list of progress data, the `ProgressController` `GET` route now responds with a single progress object or an empty object if no data can be found. [#1116](https://github.com/geli-lms/geli/issues/1116)
 
 ### Removed
@@ -31,8 +31,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `CodeKataComponent` `progress.code` loading. [#1116](https://github.com/geli-lms/geli/issues/1116)
 
 ### Security
-- Closed `ProgressController` vulnerabilities. [#1116](https://github.com/geli-lms/geli/issues/1116)
-- Closed `UnitController` vulnerabilities. [#1190](https://github.com/geli-lms/geli/issues/1190)
+- Closes `ProgressController` vulnerabilities. [#1116](https://github.com/geli-lms/geli/issues/1116)
+- Closes `UnitController` vulnerabilities. [#1190](https://github.com/geli-lms/geli/issues/1190)
 
 ## [[0.8.4](https://github.com/geli-lms/geli/releases/tag/v0.8.4)] - 2018-12-20 - WS 18/19 ❄️-Release
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `CodeKataComponent` `progress.code` loading. [#1116](https://github.com/geli-lms/geli/issues/1116)
 
 ### Security
-- Closes `ProgressController` vulnerabilities. [#1116](https://github.com/geli-lms/geli/issues/1116)
-- Closes `UnitController` vulnerabilities. [#1190](https://github.com/geli-lms/geli/issues/1190)
+- Close `ProgressController` vulnerabilities. [#1116](https://github.com/geli-lms/geli/issues/1116)
+- Close `UnitController` vulnerabilities. [#1190](https://github.com/geli-lms/geli/issues/1190)
 
 ## [[0.8.4](https://github.com/geli-lms/geli/releases/tag/v0.8.4)] - 2018-12-20 - WS 18/19 ❄️-Release
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Translatable SnackBarService. [#922](https://github.com/geli-lms/geli/issues/922)
 - `ProgressController` `GET` unit tests & access denial tests in general. [#1116](https://github.com/geli-lms/geli/issues/1116)
+- `UnitController` `GET` & `DELETE` route unit tests for status code `200`. [#1190](https://github.com/geli-lms/geli/issues/1190)
+- `UnitController` status code `403` (not authorized to view / edit course) unit tests for all routes. [#1190](https://github.com/geli-lms/geli/issues/1190)
 
 ### Changed
 - Extended `ProgressController` `PUT` route to handle both creation and updates. [#1116](https://github.com/geli-lms/geli/issues/1116)
@@ -30,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Security
 - Closed `ProgressController` vulnerabilities. [#1116](https://github.com/geli-lms/geli/issues/1116)
+- Closed `UnitController` vulnerabilities. [#1190](https://github.com/geli-lms/geli/issues/1190)
 
 ## [[0.8.4](https://github.com/geli-lms/geli/releases/tag/v0.8.4)] - 2018-12-20 - WS 18/19 ❄️-Release
 ### Added

--- a/api/src/config/errorCodes.ts
+++ b/api/src/config/errorCodes.ts
@@ -175,5 +175,19 @@ export const errorCodes = {
       code: 'pastDeadline',
       text: 'Past deadline, no further update possible'
     }
+  },
+  unit: {
+    postMissingLectureId: {
+      code: 'postMissingLectureId',
+      text: 'No lecture ID was submitted.'
+    },
+    postMissingUnit: {
+      code: 'postMissingUnit',
+      text: 'No unit was submitted.'
+    },
+    postMissingCourse: {
+      code: 'postMissingCourse',
+      text: 'Unit has no _course set'
+    }
   }
 };

--- a/api/src/controllers/UnitController.ts
+++ b/api/src/controllers/UnitController.ts
@@ -140,11 +140,16 @@ export class UnitController {
    */
   @Authorized(['teacher', 'admin'])
   @Put('/:id')
-  async updateUnit(@Param('id') id: string, @Body() data: any) {
+  async updateUnit(@Param('id') id: string, @Body() data: any, @CurrentUser() currentUser: IUser) {
     const oldUnit: IUnitModel = await Unit.findById(id);
 
     if (!oldUnit) {
       throw new NotFoundError();
+    }
+
+    const course = await Course.findById(oldUnit._course);
+    if (!course.checkPrivileges(currentUser).userCanEditCourse) {
+      throw new ForbiddenError();
     }
 
     try {

--- a/api/src/controllers/UnitController.ts
+++ b/api/src/controllers/UnitController.ts
@@ -177,12 +177,10 @@ export class UnitController {
    *
    * @apiParam {String} id Unit ID.
    *
-   * @apiSuccess {Boolean} result Confirmation of deletion.
+   * @apiSuccess {Object} result Empty object.
    *
    * @apiSuccessExample {json} Success-Response:
-   *     {
-   *         "result": true
-   *     }
+   *     {}
    *
    * @apiError NotFoundError
    * @apiError ForbiddenError
@@ -194,7 +192,7 @@ export class UnitController {
 
     await Lecture.updateMany({}, {$pull: {units: id}});
     await unit.remove();
-    return {result: true};
+    return {};
   }
 
   protected pushToLecture(lectureId: string, unit: any) {

--- a/api/src/controllers/UnitController.ts
+++ b/api/src/controllers/UnitController.ts
@@ -13,7 +13,7 @@ import {IUser} from '../../../shared/models/IUser';
 @UseBefore(passportJwtMiddleware)
 export class UnitController {
 
-  static async getUnitFor (unitId: string, currentUser: IUser, privilege: 'userCanViewCourse' | 'userCanEditCourse') {
+  protected static async getUnitFor (unitId: string, currentUser: IUser, privilege: 'userCanViewCourse' | 'userCanEditCourse') {
     const unit = await Unit.findById(unitId);
     if (!unit) {
       throw new NotFoundError();

--- a/api/src/controllers/UnitController.ts
+++ b/api/src/controllers/UnitController.ts
@@ -185,11 +185,16 @@ export class UnitController {
    */
   @Authorized(['teacher', 'admin'])
   @Delete('/:id')
-  async deleteUnit(@Param('id') id: string) {
+  async deleteUnit(@Param('id') id: string, @CurrentUser() currentUser: IUser) {
     const unit = await Unit.findById(id);
 
     if (!unit) {
       throw new NotFoundError();
+    }
+
+    const course = await Course.findById(unit._course);
+    if (!course.checkPrivileges(currentUser).userCanEditCourse) {
+      throw new ForbiddenError();
     }
 
     await Lecture.updateMany({}, {$pull: {units: id}});

--- a/api/src/controllers/UnitController.ts
+++ b/api/src/controllers/UnitController.ts
@@ -14,10 +14,7 @@ import {IUser} from '../../../shared/models/IUser';
 export class UnitController {
 
   protected static async getUnitFor (unitId: string, currentUser: IUser, privilege: 'userCanViewCourse' | 'userCanEditCourse') {
-    const unit = await Unit.findById(unitId);
-    if (!unit) {
-      throw new NotFoundError();
-    }
+    const unit = await Unit.findById(unitId).orFail(new NotFoundError());
 
     const course = await Course.findById(unit._course);
     if (!course.checkPrivileges(currentUser)[privilege]) {

--- a/api/src/controllers/UnitController.ts
+++ b/api/src/controllers/UnitController.ts
@@ -185,18 +185,16 @@ export class UnitController {
    */
   @Authorized(['teacher', 'admin'])
   @Delete('/:id')
-  deleteUnit(@Param('id') id: string) {
-    return Unit.findById(id).then((unit) => {
-      if (!unit) {
-        throw new NotFoundError();
-      }
+  async deleteUnit(@Param('id') id: string) {
+    const unit = await Unit.findById(id);
 
-      return Lecture.updateMany({}, {$pull: {units: id}})
-        .then(() => unit.remove())
-        .then(() => {
-          return {result: true};
-        });
-    });
+    if (!unit) {
+      throw new NotFoundError();
+    }
+
+    await Lecture.updateMany({}, {$pull: {units: id}});
+    await unit.remove();
+    return {result: true};
   }
 
   protected pushToLecture(lectureId: string, unit: any) {

--- a/api/src/controllers/UnitController.ts
+++ b/api/src/controllers/UnitController.ts
@@ -87,6 +87,12 @@ export class UnitController {
   async addUnit(@Body() data: any, @CurrentUser() currentUser: IUser) {
     // discard invalid requests
     this.checkPostParam(data);
+
+    const course = await Course.findById(data.model._course);
+    if (!course.checkPrivileges(currentUser).userCanEditCourse) {
+      throw new ForbiddenError();
+    }
+
     // Set current user as creator, old unit's dont have a creator
     data.model.unitCreator = currentUser._id;
     try {

--- a/api/src/controllers/UnitController.ts
+++ b/api/src/controllers/UnitController.ts
@@ -49,6 +49,9 @@ export class UnitController {
    *         "type": "free-text",
    *         "__v": 0
    *     }
+   *
+   * @apiError NotFoundError
+   * @apiError ForbiddenError
    */
   @Get('/:id')
   async getUnit(@Param('id') id: string, @CurrentUser() currentUser: IUser) {
@@ -87,6 +90,7 @@ export class UnitController {
    * @apiError BadRequestError No unit was submitted.
    * @apiError BadRequestError Unit has no _course set.
    * @apiError BadRequestError
+   * @apiError ForbiddenError
    * @apiError ValidationError
    */
   @Authorized(['teacher', 'admin'])
@@ -140,9 +144,10 @@ export class UnitController {
    *         "__v": 0
    *     }
    *
-   * @apiError NotFoundError
    * @apiError BadRequestError Invalid combination of file upload and unit data.
    * @apiError BadRequestError
+   * @apiError NotFoundError
+   * @apiError ForbiddenError
    * @apiError ValidationError
    */
   @Authorized(['teacher', 'admin'])
@@ -180,6 +185,7 @@ export class UnitController {
    *     }
    *
    * @apiError NotFoundError
+   * @apiError ForbiddenError
    */
   @Authorized(['teacher', 'admin'])
   @Delete('/:id')

--- a/api/src/controllers/UnitController.ts
+++ b/api/src/controllers/UnitController.ts
@@ -182,10 +182,7 @@ export class UnitController {
   }
 
   private async getUnitFor (unitId: string, currentUser: IUser, privilege: 'userCanViewCourse' | 'userCanEditCourse') {
-    const unit = await Unit.findById(unitId);
-    if (!unit) {
-      throw new NotFoundError();
-    }
+    const unit = await Unit.findById(unitId).orFail(new NotFoundError());
 
     const course = await Course.findById(unit._course);
     if (!course.checkPrivileges(currentUser)[privilege]) {

--- a/api/src/controllers/UnitController.ts
+++ b/api/src/controllers/UnitController.ts
@@ -3,7 +3,7 @@ import {
   Authorized, CurrentUser, ForbiddenError
 } from 'routing-controllers';
 import passportJwtMiddleware from '../security/passportJwtMiddleware';
-
+import {errorCodes} from '../config/errorCodes';
 import {Course} from '../models/Course';
 import {Lecture} from '../models/Lecture';
 import {IUnitModel, Unit} from '../models/units/Unit';
@@ -216,15 +216,15 @@ export class UnitController {
 
   protected checkPostParam(data: any) {
     if (!data.lectureId) {
-      throw new BadRequestError('No lecture ID was submitted.');
+      throw new BadRequestError(errorCodes.unit.postMissingLectureId.text);
     }
 
     if (!data.model) {
-      throw new BadRequestError('No unit was submitted.');
+      throw new BadRequestError(errorCodes.unit.postMissingUnit.text);
     }
 
     if (!data.model._course) {
-      throw new BadRequestError('Unit has no _course set');
+      throw new BadRequestError(errorCodes.unit.postMissingCourse.text);
     }
   }
 }

--- a/api/test/integration/unit/codeKataUnit.ts
+++ b/api/test/integration/unit/codeKataUnit.ts
@@ -39,6 +39,17 @@ describe(`CodeKataUnit ${BASE_URL}`, () => {
     await testHelper.resetForNextTest();
   });
 
+  describe(`GET ${BASE_URL}`, () => {
+    it('should get unit data', async () => {
+      const unit = await Unit.findOne({__t: 'code-kata'});
+      const course = await Course.findById(unit._course);
+      const courseAdmin = await User.findById(course.courseAdmin);
+
+      const res = await testHelper.commonUserGetRequest(courseAdmin, `/${unit.id}`);
+      res.status.should.be.equal(200);
+    });
+  });
+
   describe(`POST ${BASE_URL}`, () => {
     it('should fail with wrong authorization', async () => {
       const res = await chai.request(app)

--- a/api/test/integration/unit/codeKataUnit.ts
+++ b/api/test/integration/unit/codeKataUnit.ts
@@ -2,7 +2,6 @@ import * as chai from 'chai';
 import chaiHttp = require('chai-http');
 import {TestHelper} from '../../TestHelper';
 import {Server} from '../../../src/server';
-import {JwtUtils} from '../../../src/security/JwtUtils';
 import {User} from '../../../src/models/User';
 import {Lecture} from '../../../src/models/Lecture';
 import {Course} from '../../../src/models/Course';
@@ -111,11 +110,7 @@ describe(`CodeKataUnit ${BASE_URL}`, () => {
       const courseAdmin = await User.findOne({_id: course.courseAdmin});
       (<ICodeKataModel>unit).test += '\n// Test if we can edit a Kata';
 
-      const res = await chai.request(app)
-        .put(BASE_URL + '/' + unit.id)
-        .set('Cookie', `token=${JwtUtils.generateToken(courseAdmin)}`)
-        .send(unit.toObject());
-
+      const res = await testHelper.commonUserPutRequest(courseAdmin, `/${unit.id}`, unit.toObject());
       res.status.should.be.equal(200);
       res.body.test.should.string('// Test if we can edit a Kata');
     });

--- a/api/test/integration/unit/codeKataUnit.ts
+++ b/api/test/integration/unit/codeKataUnit.ts
@@ -126,4 +126,18 @@ describe(`CodeKataUnit ${BASE_URL}`, () => {
       res.body.test.should.string('// Test if we can edit a Kata');
     });
   });
+
+  describe(`DELETE ${BASE_URL}`, () => {
+    it('should delete unit', async () => {
+      const unit = await Unit.findOne({__t: 'code-kata'});
+      const course = await Course.findById(unit._course);
+      const courseAdmin = await User.findById(course.courseAdmin);
+
+      const res = await testHelper.commonUserDeleteRequest(courseAdmin, `/${unit.id}`);
+      res.status.should.be.equal(200);
+
+      const res2 = await testHelper.commonUserGetRequest(courseAdmin, `/${unit.id}`);
+      res2.status.should.be.equal(404);
+    });
+  });
 });

--- a/api/test/integration/unit/codeKataUnit.ts
+++ b/api/test/integration/unit/codeKataUnit.ts
@@ -172,12 +172,13 @@ describe(`CodeKataUnit ${BASE_URL}`, () => {
     it('should fail to delete unit for an unauthorized teacher', async () => {
       const unit = await Unit.findOne({__t: 'code-kata'});
       const course = await Course.findById(unit._course);
+      const courseAdmin = await User.findById(course.courseAdmin);
       const unauthorizedTeacher = await FixtureUtils.getUnauthorizedTeacherForCourse(course);
 
       const res = await testHelper.commonUserDeleteRequest(unauthorizedTeacher, `/${unit.id}`);
       res.status.should.be.equal(403);
 
-      const res2 = await testHelper.commonUserGetRequest(unauthorizedTeacher, `/${unit.id}`);
+      const res2 = await testHelper.commonUserGetRequest(courseAdmin, `/${unit.id}`);
       res2.status.should.be.equal(200);
     });
   });

--- a/api/test/integration/unit/codeKataUnit.ts
+++ b/api/test/integration/unit/codeKataUnit.ts
@@ -101,7 +101,9 @@ describe(`CodeKataUnit ${BASE_URL}`, () => {
       res.body.unitCreator.profile.lastName.should.equal(courseAdmin.profile.lastName);
       res.body.unitCreator.profile.firstName.should.equal(courseAdmin.profile.firstName);
     });
+  });
 
+  describe(`PUT ${BASE_URL}`, () => {
     it('should update a codeKata', async () => {
       const unit = await Unit.findOne({__t: 'code-kata'});
       const lecture = await Lecture.findOne({units: { $in: [ unit._id ] }});


### PR DESCRIPTION
## Description:

Closes #1190

Fixes `UnitController` vulnerabilities.

## Improvements:
- Closed vulnerabilities for all 4 routes via `course.checkPrivileges`.
- Added `GET` & `DELETE` route unit tests for status code `200`.
- Added status code `403` (not authorized to view / edit course) unit tests for all 4 routes.
- Some related unit test refactoring _(could definitely be refactored further)_.
- `DELETE` route now returns a completely empty object _(very minor change)_.
- Other minor refactoring, such as `async`/`await` usage and `errorCodes` refactoring.

## Known Issues:
The `DELETE` route uses `await unit.remove()`, which gives a `DeprecationWarning: collection.remove is deprecated. Use deleteOne, deleteMany, or bulkWrite instead.`, but `deleteOne` is still missing middleware support (which `Unit` makes use of): Automattic/mongoose#7195 & https://mongoosejs.com/docs/api.html#model_Model.deleteOne
_This problem wasn't introduced by this PR, I just noticed it while running the unit tests, but left it be due to the middleware regression._

<!--
ATTENTION:
Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix.
-->
