### PR TITLE
Fix: parser plugin 'param' not found in block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Bump version number to 0.8.6. [#1206](https://github.com/geli-lms/geli/pull/1206)
 
+### Fixed
+- Apidoc: parser plugin 'param' not found in block. [#1207](https://github.com/geli-lms/geli/pull/1207)
+
 ## [[0.8.5](https://github.com/geli-lms/geli/releases/tag/v0.8.5)] - 2019-03-26 - WS 18/19 🎉-Release
 ### Added
 - Translatable SnackBarService. [#922](https://github.com/geli-lms/geli/issues/922)

--- a/api/src/controllers/UnitController.ts
+++ b/api/src/controllers/UnitController.ts
@@ -305,10 +305,9 @@ export class UnitController {
    * Is called when the user wants to add a file to the assignment.
    * The user can add as much file as she wants as long as the assignment is not finalized/submitted yet.
    *
-   * @param unitId
-   * @param uploadedFile
-   * @param currentUser
-   *
+   * @apiParam unitId
+   * @apiParam uploadedFile
+   * @apiParam currentUser
    *
    * @apiError NotFoundError The unit was not found or there isn't an assignment from the current user in the unit.
    */
@@ -484,7 +483,7 @@ export class UnitController {
    * @apiGroup Unit
    *
    * @apiParam {String} id Unit ID.
-   * @apiPara {String} assignment Assignment id.
+   * @apiParam {String} assignment Assignment id.
    *
    * @apiSuccess {Unit} unit Unit.
    *

--- a/api/src/controllers/UnitController.ts
+++ b/api/src/controllers/UnitController.ts
@@ -305,9 +305,8 @@ export class UnitController {
    * Is called when the user wants to add a file to the assignment.
    * The user can add as much file as she wants as long as the assignment is not finalized/submitted yet.
    *
-   * @apiParam unitId
-   * @apiParam uploadedFile
-   * @apiParam currentUser
+   * @apiParam {String} unitId
+   * @apiParam {Object} uploadedFile
    *
    * @apiError NotFoundError The unit was not found or there isn't an assignment from the current user in the unit.
    */

--- a/api/src/controllers/UnitController.ts
+++ b/api/src/controllers/UnitController.ts
@@ -307,6 +307,7 @@ export class UnitController {
    *
    * @apiParam {String} unitId
    * @apiParam {Object} uploadedFile
+   * @apiParam {IUser} currentUser
    *
    * @apiError NotFoundError The unit was not found or there isn't an assignment from the current user in the unit.
    */


### PR DESCRIPTION
## Description:

Fix some warnings from apidoc

## Improvements
- apidoc is happy